### PR TITLE
[FEAT] Mock API 세팅 및 Swagger 연동

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@
 - [시퀀스 다이어그램](docs/sequenceDiagram.md)
 - [ERD](docs/erd.md)
 
-## MockAPI Swagger
+## Swagger
 
-domain - infra - application 개발 .. ... 
+http://localhost:8080/swagger-ui/index.html

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     //Swagger
-    implementation("org.springdoc:springdoc-openapi-ui:1.8.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 
     // DB
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/java/kr/server/pointly/PointlyApplication.java
+++ b/src/main/java/kr/server/pointly/PointlyApplication.java
@@ -1,0 +1,13 @@
+package kr.server.pointly;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PointlyApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PointlyApplication.class, args);
+    }
+
+}

--- a/src/main/java/kr/server/pointly/domain/user/FindUserSortType.java
+++ b/src/main/java/kr/server/pointly/domain/user/FindUserSortType.java
@@ -1,0 +1,15 @@
+package kr.server.pointly.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FindUserSortType {
+
+    NAME("name"),
+    VIEW_COUNT("viewCount"),
+    CREATED_AT("createdAt");
+
+    private final String field;
+}

--- a/src/main/java/kr/server/pointly/interfaces/common/PageResponse.java
+++ b/src/main/java/kr/server/pointly/interfaces/common/PageResponse.java
@@ -1,0 +1,13 @@
+package kr.server.pointly.interfaces.common;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalCount,
+        int totalPages
+) {
+
+}

--- a/src/main/java/kr/server/pointly/interfaces/point/PointController.java
+++ b/src/main/java/kr/server/pointly/interfaces/point/PointController.java
@@ -1,0 +1,35 @@
+package kr.server.pointly.interfaces.point;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+public class PointController implements PointDocs{
+
+
+    @Override
+    @PostMapping("/api/v1/users/{userId}/points/charge")
+    public ResponseEntity<PointResponse.ChargeResponse> requestCharge(
+            @PathVariable Long userId
+            , @RequestBody PointRequest.RequestCharge request) {
+        return ResponseEntity.ok(new PointResponse.ChargeResponse(userId, 1L, 1000L, "TOSS", LocalDateTime.of(2025, 7, 18, 0, 0, 0)));
+    }
+
+    @Override
+    @PatchMapping("/api/v1/users/{userId}/points/charge/approve")
+    public ResponseEntity<PointResponse.ChargeCompletedResponse> completeCharge(
+            @PathVariable Long userId
+            , @RequestBody PointRequest.CompleteCharge request) {
+        return ResponseEntity.ok(new PointResponse.ChargeCompletedResponse(1L, 10000L,1L, 5000L, "TOSS", LocalDateTime.of(2025, 7, 18, 0, 0, 0)));
+    }
+
+    @Override
+    @PatchMapping("/api/v1/users/{userId}/points/charge/cancel")
+    public ResponseEntity<PointResponse.ChargeCanceledResponse> cancelCharge(
+            @PathVariable Long userId
+            , @RequestBody PointRequest.CancelCharge request) {
+        return ResponseEntity.ok(new PointResponse.ChargeCanceledResponse(1L, 1L, LocalDateTime.of(2025, 7, 18, 0, 0, 0)));
+    }
+}

--- a/src/main/java/kr/server/pointly/interfaces/point/PointDocs.java
+++ b/src/main/java/kr/server/pointly/interfaces/point/PointDocs.java
@@ -1,0 +1,114 @@
+package kr.server.pointly.interfaces.point;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "point", description = "point API")
+public interface PointDocs {
+
+    @Operation(summary = "포인트 충전 결제 요청", description = "포인트 충전을 요청합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "포인트 충전 요청 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PointResponse.ChargeResponse.class),
+                    examples = @ExampleObject(value = """
+                        {\s
+                            "userId": 1,
+                            "paymentId": 1,
+                            "amount": 5000,
+                            "type": "TOSS",
+                            "paidRequestAt": "2025-07-18T00:00:00"
+                        }
+                   \s""")
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "조회된 유저가 없습니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = """
+                {
+                  "code": 400,
+                  "message": "조회된 유저가 없습니다."
+                }
+                """)
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "지원하지 않는 결제 유형입니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = """
+                {
+                  "code": 400,
+                  "message": "지원하지 않는 결제 유형입니다."
+                }
+                """)
+            )
+    )
+    ResponseEntity<PointResponse.ChargeResponse> requestCharge (
+            @PathVariable Long userId,
+            @RequestBody PointRequest.RequestCharge request
+    );
+
+    @Operation(summary = "포인트 충전 결제 완료", description = "결제가 완료되어 충전 완료를 요청합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "포인트 충전 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PointResponse.ChargeCompletedResponse.class),
+                    examples = @ExampleObject(value = """
+                        {\s
+                            "userId": 1,
+                            "balance" : 10000,
+                            "paymentId": 1,
+                            "paidAmount": 5000,
+                            "paymentType": "TOSS",
+                            "paidAt": "2025-07-18T00:00:00"
+                        }
+                   \s""")
+            )
+    )
+    ResponseEntity<PointResponse.ChargeCompletedResponse> completeCharge (
+            @PathVariable Long userId,
+            @RequestBody PointRequest.CompleteCharge request
+    );
+
+    @Operation(summary = "포인트 충전 결제 취소", description = "결제에 실패하여 충전 취소를 요청합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "포인트 충전 결제 취소 처리 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PointResponse.ChargeCanceledResponse.class),
+                    examples = @ExampleObject(value = """
+                        {\s
+                            "userId": 1,
+                            "paymentId": 1,
+                            "canceledAt": "2025-07-18T00:00:00"
+                        }
+                   \s""")
+            )
+    )
+    ResponseEntity<PointResponse.ChargeCanceledResponse> cancelCharge (
+            @PathVariable Long userId,
+            @RequestBody PointRequest.CancelCharge request
+    );
+
+}
+

--- a/src/main/java/kr/server/pointly/interfaces/point/PointRequest.java
+++ b/src/main/java/kr/server/pointly/interfaces/point/PointRequest.java
@@ -1,0 +1,26 @@
+package kr.server.pointly.interfaces.point;
+
+public record PointRequest(
+
+) {
+    public record RequestCharge(
+            Long amount,
+            String paymentType
+    ){
+    }
+
+    public record CompleteCharge(
+            Long paymentId,
+            Long amount,
+            String paymentType,
+            String paymentToken
+    ){
+
+    }
+
+    public record CancelCharge(
+            Long paymentId
+    ){
+
+    }
+}

--- a/src/main/java/kr/server/pointly/interfaces/point/PointResponse.java
+++ b/src/main/java/kr/server/pointly/interfaces/point/PointResponse.java
@@ -1,0 +1,36 @@
+package kr.server.pointly.interfaces.point;
+
+import java.time.LocalDateTime;
+
+public record PointResponse(
+
+) {
+    public record ChargeResponse(
+        Long userId,
+        Long paymentId,
+        Long amount,
+        String paymentType,
+        LocalDateTime paidRequestAt
+    ) {
+
+    }
+
+    public record ChargeCompletedResponse(
+            Long userId,
+            Long balance,
+            Long paymentId,
+            Long paidAmount,
+            String paymentType,
+            LocalDateTime paidAt
+    ){
+
+    }
+
+    public record ChargeCanceledResponse (
+            Long userId,
+            Long paymentId,
+            LocalDateTime canceledAt
+    ) {
+
+    }
+}

--- a/src/main/java/kr/server/pointly/interfaces/user/UserController.java
+++ b/src/main/java/kr/server/pointly/interfaces/user/UserController.java
@@ -1,0 +1,35 @@
+package kr.server.pointly.interfaces.user;
+
+import kr.server.pointly.interfaces.common.PageResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+public class UserController implements UserDocs{
+
+    @Override
+    @GetMapping("/api/v1/users")
+    public ResponseEntity<PageResponse<UserResponse>> findAll(UserRequest.FindAll request) {
+        return ResponseEntity.ok(new PageResponse<>(
+                List.of( new UserResponse(1L, "이건엽", 5L, LocalDate.of(2025, 7, 14))
+                ,new UserResponse(1L, "홍길동", 10L, LocalDate.of(2025, 7, 13))
+                ,new UserResponse(1L, "정지훈", 20L, LocalDate.of(2025, 7, 12))
+                ,new UserResponse(1L, "박재혁", 30L, LocalDate.of(2025, 7, 11))),
+                        1, 10, 4, 1));
+    }
+
+    @Override
+    @PatchMapping("/api/v1/users/{userId}/view")
+    public ResponseEntity<UserResponse.AddView> addView(
+                    @PathVariable Long userId,
+                    UserRequest.AddView request) {
+        return ResponseEntity.ok(new UserResponse.AddView(1L, 5L, LocalDateTime.of(2025, 7, 18, 0, 0, 0)));
+    }
+}

--- a/src/main/java/kr/server/pointly/interfaces/user/UserDocs.java
+++ b/src/main/java/kr/server/pointly/interfaces/user/UserDocs.java
@@ -1,0 +1,114 @@
+package kr.server.pointly.interfaces.user;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.server.pointly.interfaces.common.PageResponse;
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "user", description = "user API")
+public interface UserDocs {
+
+    @Operation(summary = "회원 프로필 목록 조회", description = "회원 프로필 목록을 조회합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "회원 프로필 목록 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PageResponse.class),
+                    examples = @ExampleObject(value = """
+                        {\s
+                            content : [
+                                {\s
+                                    "userId": 1,
+                                    "name": "이건엽",
+                                    "viewCount": 5,
+                                    "createAt": "2024-07-14"
+                                },
+                                {\s
+                                    "userId": 2,
+                                    "name": "홍길동",
+                                    "viewCount": 10,
+                                    "createAt": "2024-07-13"
+                                },
+                                {\s
+                                    "userId": 3,
+                                    "name": "정지훈",
+                                    "viewCount": 20,
+                                    "createAt": "2024-07-12"
+                                },
+                                {\s
+                                    "userId": 4,
+                                    "name": "박재혁",
+                                    "viewCount": 30,
+                                    "createAt": "2024-07-11"
+                                },
+                            ],
+                            page: 1,
+                            size: 10,
+                            totalCount : 4,
+                            totalPage : 1
+                        }
+                   \s""")
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 정렬 요청",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = """
+                {
+                  "code": 400,
+                  "message": "제공하지 않는 정렬 방식입니다."
+                }
+                """)
+            )
+    )
+    ResponseEntity<PageResponse<UserResponse>> findAll (
+            @ParameterObject UserRequest.FindAll request
+    );
+
+    @Operation(summary = "회원 프로필 조회수 증가", description = "회원 프로필의 조회수를 증가시킵니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "회원 프로필 조회수 증가 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PageResponse.class),
+                    examples = @ExampleObject(value = """
+                        {\s
+                            "userId": 1,
+                            "viewCount": 5,
+                            "modifiedAt": "2025-07-18T00:00:00"
+                        }
+                   \s""")
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "조회된 유저가 없습니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = """
+                {
+                  "code": 400,
+                  "message": "조회된 유저가 없습니다."
+                }
+                """)
+            )
+    )
+    ResponseEntity<UserResponse.AddView> addView (
+            @PathVariable Long userId,
+            @ParameterObject UserRequest.AddView request
+    );
+}

--- a/src/main/java/kr/server/pointly/interfaces/user/UserDocs.java
+++ b/src/main/java/kr/server/pointly/interfaces/user/UserDocs.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.server.pointly.interfaces.common.PageResponse;
-import org.springdoc.api.annotations.ParameterObject;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,39 +24,39 @@ public interface UserDocs {
                     mediaType = "application/json",
                     schema = @Schema(implementation = PageResponse.class),
                     examples = @ExampleObject(value = """
-                        {\s
-                            content : [
-                                {\s
+                        {
+                            "content": [
+                                {
                                     "userId": 1,
                                     "name": "이건엽",
                                     "viewCount": 5,
                                     "createAt": "2024-07-14"
                                 },
-                                {\s
+                                {
                                     "userId": 2,
                                     "name": "홍길동",
                                     "viewCount": 10,
                                     "createAt": "2024-07-13"
                                 },
-                                {\s
+                                {
                                     "userId": 3,
                                     "name": "정지훈",
                                     "viewCount": 20,
                                     "createAt": "2024-07-12"
                                 },
-                                {\s
+                                {
                                     "userId": 4,
                                     "name": "박재혁",
                                     "viewCount": 30,
                                     "createAt": "2024-07-11"
-                                },
+                                }
                             ],
-                            page: 1,
-                            size: 10,
-                            totalCount : 4,
-                            totalPage : 1
+                            "page": 1,
+                            "size": 10,
+                            "totalCount": 4,
+                            "totalPage": 1
                         }
-                   \s""")
+                    """)
             )
     )
     @ApiResponse(

--- a/src/main/java/kr/server/pointly/interfaces/user/UserRequest.java
+++ b/src/main/java/kr/server/pointly/interfaces/user/UserRequest.java
@@ -1,0 +1,19 @@
+package kr.server.pointly.interfaces.user;
+
+import kr.server.pointly.domain.user.FindUserSortType;
+
+public record UserRequest(
+
+) {
+    public record FindAll(
+            int page,
+            int size,
+            FindUserSortType sortType
+    ){
+
+    }
+
+    public record AddView(){
+
+    }
+}

--- a/src/main/java/kr/server/pointly/interfaces/user/UserResponse.java
+++ b/src/main/java/kr/server/pointly/interfaces/user/UserResponse.java
@@ -1,0 +1,19 @@
+package kr.server.pointly.interfaces.user;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record UserResponse(
+        Long userId,
+        String name,
+        Long viewCount,
+        LocalDate createAt
+) {
+    public record AddView(
+            Long userId,
+            Long viewCount,
+            LocalDateTime modifiedAt
+    ){
+
+    }
+}

--- a/src/main/java/kr/server/pointly/support/config/SwaggerConfig.java
+++ b/src/main/java/kr/server/pointly/support/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package kr.server.pointly.support.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Pointly API")
+                        .version("1.0.0")
+                        .description("Pointly API 문서입니다."));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,6 @@
-spring.application.name=pointly
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method

--- a/src/test/java/kr/server/pointly/PointlyApplicationTests.java
+++ b/src/test/java/kr/server/pointly/PointlyApplicationTests.java
@@ -1,0 +1,13 @@
+package kr.server.pointly;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PointlyApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/src/test/java/kr/server/pointly/interfaces/point/PointControllerTest.java
+++ b/src/test/java/kr/server/pointly/interfaces/point/PointControllerTest.java
@@ -1,0 +1,84 @@
+package kr.server.pointly.interfaces.point;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PointController.class)
+class PointControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("포인트 충전을 위해 결제 요청을 하면 결제 예정 정보를 받는다.")
+    @Test
+    void requestCharge() throws Exception {
+        // given
+        Long userId = 1L;
+        PointRequest.RequestCharge request = new PointRequest.RequestCharge( 1000L, "TOSS");
+
+        // when then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/users/{userId}/points/charge", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1L))
+                .andExpect(jsonPath("$.paymentId").value(1L))
+                .andExpect(jsonPath("$.amount").value(request.amount()))
+                .andExpect(jsonPath("$.paymentType").value(request.paymentType()))
+                .andExpect(jsonPath("$.paidRequestAt").value("2025-07-18T00:00:00"));
+    }
+
+    @DisplayName("포인트 충전을 위한 결제 완료 요청 시 충전된 포인트 정보와 결제 정보를 받는다.")
+    @Test
+    void completeCharge() throws Exception{
+        // given
+        Long userId = 1L;
+        PointRequest.CompleteCharge request = new PointRequest.CompleteCharge( 1L, 1000L, "TOSS", "keykeykey");
+
+        // when then
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/users/{userId}/points/charge/approve", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1L))
+                .andExpect(jsonPath("$.balance").value(10000L))
+                .andExpect(jsonPath("$.paymentId").value(1L))
+                .andExpect(jsonPath("$.paidAmount").value(5000L))
+                .andExpect(jsonPath("$.paymentType").value(request.paymentType()))
+                .andExpect(jsonPath("$.paidAt").value("2025-07-18T00:00:00"));
+    }
+
+    @DisplayName("포인트 충전 취소 요청 시 취소된 결제 정보를 받는다.")
+    @Test
+    void cancelCharge() throws Exception{
+        // given
+
+        Long userId = 1L;
+        PointRequest.CancelCharge request = new PointRequest.CancelCharge(1L);
+
+        // when then
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/users/{userId}/points/charge/cancel", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1L))
+                .andExpect(jsonPath("$.paymentId").value(1L))
+                .andExpect(jsonPath("$.canceledAt").value("2025-07-18T00:00:00"));
+    }
+}

--- a/src/test/java/kr/server/pointly/interfaces/user/UserControllerTest.java
+++ b/src/test/java/kr/server/pointly/interfaces/user/UserControllerTest.java
@@ -1,0 +1,61 @@
+package kr.server.pointly.interfaces.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @DisplayName("회원 목록 조회 요청 시 페이징 처리 된 회원 목록을 받는다.")
+    @Test
+    void findAll() throws Exception {
+        //given
+        UserRequest.FindAll request =
+                new UserRequest.FindAll(1, 10, null);
+        // when then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/users")
+                        .queryParam("page", String.valueOf(request.page()))
+                        .queryParam("size", String.valueOf(request.size())))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.page").value(request.page()))
+                .andExpect(jsonPath("$.size").value(request.size()))
+                .andExpect(jsonPath("$.totalCount").value(4))
+                .andExpect(jsonPath("$.totalPages").value(1))
+        ;
+    }
+
+    @DisplayName("userId와 함께 조회수 증가를 요청하면 해당되는 유저의 증가된 조회수 정보를 받는다.")
+    @Test
+    void addView() throws Exception {
+        // given
+        UserResponse.AddView response = new UserResponse.AddView(1L, 5L, LocalDateTime.of(2025, 7, 18, 0, 0, 0));
+
+        UserRequest.FindAll request =
+                new UserRequest.FindAll(1, 10, null);
+
+
+        // when // then
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/users/{userId}/view", 1L))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.userId").value(response.userId()))
+                    .andExpect(jsonPath("$.viewCount").value(response.viewCount()))
+                    .andExpect(jsonPath("$.modifiedAt").value("2025-07-18T00:00:00"))
+        ;
+    }
+}


### PR DESCRIPTION
## ISSUE
- #3 

## PR 내용

- 유저 목록 조회, 조회수 증가, 포인트 충전 결제에 관한 API에 대한 Mock API 세팅 88b2e5f12db42e37dfcb0956cc0cff670673b20f
- Swagger 연동 6c548fb5661e4dafa8582b93512d041f6082d967

http://localhost:8080/swagger-ui/index.html 서버를 실행시킨 뒤 해당 페이지에서 Mock API를 호출해볼 수 있습니다.