### PR TITLE
[FEAT] Point Domain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-web")
-    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
+    implementation("org.springframework.retry:spring-retry")
 
     // TEST
     testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -39,6 +39,9 @@ dependencies {
 
     //Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+
+    //Docker
+    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
 
     // DB
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/java/kr/server/pointly/domain/point/Point.java
+++ b/src/main/java/kr/server/pointly/domain/point/Point.java
@@ -1,0 +1,44 @@
+package kr.server.pointly.domain.point;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+import kr.server.pointly.domain.common.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Point extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private Long balance;
+
+    @Version
+    private Long version;
+
+    private Point(Long userId, Long balance) {
+        this.userId = userId;
+        this.balance = balance;
+    }
+
+    public static Point create(Long userId, Long balance) {
+        return new Point(userId, balance);
+    }
+
+    public void charge(Long amount) {
+        if (amount < 1) {
+            throw new IllegalArgumentException("포인트 충전은 1원 이상부터 가능합니다.");
+        }
+        this.balance += amount;
+    }
+}

--- a/src/main/java/kr/server/pointly/domain/point/PointCommand.java
+++ b/src/main/java/kr/server/pointly/domain/point/PointCommand.java
@@ -1,0 +1,11 @@
+package kr.server.pointly.domain.point;
+
+public record PointCommand() {
+
+    public record Charge(
+            Long userId,
+            Long amount
+    ) {
+
+    }
+}

--- a/src/main/java/kr/server/pointly/domain/point/PointHistory.java
+++ b/src/main/java/kr/server/pointly/domain/point/PointHistory.java
@@ -1,0 +1,37 @@
+package kr.server.pointly.domain.point;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class PointHistory {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    private Long pointId;
+    private TransactionType type;
+    private Long amount;
+    LocalDateTime createdAt;
+
+    private PointHistory(Long pointId, TransactionType type, Long amount, LocalDateTime createdAt) {
+        this.pointId = pointId;
+        this.type = type;
+        this.amount = amount;
+        this.createdAt = createdAt;
+    }
+
+    public static PointHistory create(Long pointId, TransactionType type, Long amount, LocalDateTime createdAt) {
+        return new PointHistory(pointId, type, amount, createdAt);
+    }
+}

--- a/src/main/java/kr/server/pointly/domain/point/PointHistoryRepository.java
+++ b/src/main/java/kr/server/pointly/domain/point/PointHistoryRepository.java
@@ -1,0 +1,5 @@
+package kr.server.pointly.domain.point;
+
+public interface PointHistoryRepository {
+    void save(PointHistory pointHistory);
+}

--- a/src/main/java/kr/server/pointly/domain/point/PointRepository.java
+++ b/src/main/java/kr/server/pointly/domain/point/PointRepository.java
@@ -1,0 +1,7 @@
+package kr.server.pointly.domain.point;
+
+import java.util.Optional;
+
+public interface PointRepository {
+    Optional<Point> findByUserId(Long userId);
+}

--- a/src/main/java/kr/server/pointly/domain/point/PointService.java
+++ b/src/main/java/kr/server/pointly/domain/point/PointService.java
@@ -1,0 +1,38 @@
+package kr.server.pointly.domain.point;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PointService {
+
+
+    private final PointRepository pointRepository;
+
+    private final PointHistoryRepository pointHistoryRepository;
+
+    @Retryable(
+            retryFor = OptimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100, multiplier = 2)      // 100ms → 200ms → 400ms
+    )
+    public Point charge(PointCommand.Charge command) {
+        Point point = pointRepository.findByUserId(command.userId())
+                .orElseThrow(() -> new IllegalArgumentException("해당되는 유저가 없습니다."));
+
+        point.charge(command.amount());
+
+        pointHistoryRepository.save(PointHistory.create(point.getId(), TransactionType.CHARGED, command.amount(), LocalDateTime.now()));
+
+        return point;
+    }
+
+}

--- a/src/main/java/kr/server/pointly/domain/point/TransactionType.java
+++ b/src/main/java/kr/server/pointly/domain/point/TransactionType.java
@@ -1,0 +1,9 @@
+package kr.server.pointly.domain.point;
+
+
+import lombok.Getter;
+
+@Getter
+public enum TransactionType {
+    CHARGED
+}

--- a/src/main/java/kr/server/pointly/infrastructure/point/JpaPointHistoryRepository.java
+++ b/src/main/java/kr/server/pointly/infrastructure/point/JpaPointHistoryRepository.java
@@ -1,0 +1,8 @@
+package kr.server.pointly.infrastructure.point;
+
+import kr.server.pointly.domain.point.PointHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaPointHistoryRepository extends JpaRepository<PointHistory, Long> {
+
+}

--- a/src/main/java/kr/server/pointly/infrastructure/point/JpaPointRepository.java
+++ b/src/main/java/kr/server/pointly/infrastructure/point/JpaPointRepository.java
@@ -1,0 +1,10 @@
+package kr.server.pointly.infrastructure.point;
+
+import kr.server.pointly.domain.point.Point;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JpaPointRepository extends JpaRepository<Point, Long>{
+    Optional<Point> findByUserId(Long userId);
+}

--- a/src/main/java/kr/server/pointly/infrastructure/point/PointHistoryRepositoryImpl.java
+++ b/src/main/java/kr/server/pointly/infrastructure/point/PointHistoryRepositoryImpl.java
@@ -1,0 +1,18 @@
+package kr.server.pointly.infrastructure.point;
+
+import kr.server.pointly.domain.point.PointHistory;
+import kr.server.pointly.domain.point.PointHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PointHistoryRepositoryImpl implements PointHistoryRepository {
+
+    private final JpaPointHistoryRepository jpaPointHistoryRepository;
+
+    @Override
+    public void save(PointHistory pointHistory) {
+        jpaPointHistoryRepository.save(pointHistory);
+    }
+}

--- a/src/main/java/kr/server/pointly/infrastructure/point/PointRepositoryImpl.java
+++ b/src/main/java/kr/server/pointly/infrastructure/point/PointRepositoryImpl.java
@@ -1,0 +1,20 @@
+package kr.server.pointly.infrastructure.point;
+
+import kr.server.pointly.domain.point.Point;
+import kr.server.pointly.domain.point.PointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PointRepositoryImpl implements PointRepository {
+
+    private final JpaPointRepository jpaPointRepository;
+
+    @Override
+    public Optional<Point> findByUserId(Long userId) {
+        return jpaPointRepository.findByUserId(userId);
+    }
+}

--- a/src/test/java/kr/server/pointly/domain/point/PointConcurrencyTest.java
+++ b/src/test/java/kr/server/pointly/domain/point/PointConcurrencyTest.java
@@ -1,0 +1,71 @@
+package kr.server.pointly.domain.point;
+
+import kr.server.pointly.infrastructure.point.JpaPointHistoryRepository;
+import kr.server.pointly.infrastructure.point.JpaPointRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class PointConcurrencyTest {
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private JpaPointRepository jpaPointRepository;
+
+    @Autowired
+    private JpaPointHistoryRepository jpaPointHistoryRepository;
+
+    @AfterEach
+    void tearDown() {
+        jpaPointRepository.deleteAllInBatch();
+        jpaPointHistoryRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("한 유저가 포인트 충전을 동시에 10회 시도할 시 성공한 만큼만 포인트가 충전된다.")
+    @Test
+    void charge() throws InterruptedException {
+        // given
+        Point point = jpaPointRepository.save(Point.create(1L, 0L));
+
+        AtomicInteger successCnt = new AtomicInteger();
+        Long userId = point.getUserId();
+        Long amount = 1000L;
+
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try{
+                    pointService.charge(new PointCommand.Charge(userId, amount));
+                    successCnt.getAndIncrement();
+                }catch(Exception e){
+                    e.printStackTrace();
+                }finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        //then
+        assertThat(successCnt.get()).isNotZero();
+        jpaPointRepository.findById(userId)
+                .ifPresent(finalPoint -> assertThat(finalPoint.getBalance()).isEqualTo(successCnt.get() * amount));
+    }
+}

--- a/src/test/java/kr/server/pointly/domain/point/PointServiceIntegrationTest.java
+++ b/src/test/java/kr/server/pointly/domain/point/PointServiceIntegrationTest.java
@@ -1,0 +1,70 @@
+package kr.server.pointly.domain.point;
+
+import kr.server.pointly.infrastructure.point.JpaPointHistoryRepository;
+import kr.server.pointly.infrastructure.point.JpaPointRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class PointServiceIntegrationTest {
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private JpaPointRepository jpaPointRepository;
+
+    @Autowired
+    private JpaPointHistoryRepository jpaPointHistoryRepository;
+
+    @Nested
+    class Charge {
+
+        @DisplayName("userId에 해당하는 유저의 포인트를 amount만큼 충전한다.")
+        @Test
+        void success() {
+            // given
+            Long userId = 1L;
+            Long amount = 1000L;
+            PointCommand.Charge command = new PointCommand.Charge(userId, amount);
+            jpaPointRepository.save(Point.create(1L, 1000L));
+
+            // when
+            Point chargedPoint = pointService.charge(command);
+
+            // then
+            assertThat(chargedPoint).isNotNull();
+            assertThat(chargedPoint.getBalance()).isEqualTo(2000L);
+            assertThat(chargedPoint.getUserId()).isEqualTo(1L);
+            List<PointHistory> historyList = jpaPointHistoryRepository.findAll();
+            assertThat(historyList).hasSize(1);
+            PointHistory pointHistory = historyList.getFirst();
+            assertThat(pointHistory.getType()).isEqualTo(TransactionType.CHARGED);
+            assertThat(pointHistory.getAmount()).isEqualTo(amount);
+        }
+
+        @DisplayName("userId에 해당하는 point를 조회하지 못한 경우 IllegalArgumentException 발생한다.")
+        @Test
+        void fail() {
+            // given
+            Long userId = 1L;
+            Long amount = 1000L;
+            PointCommand.Charge command = new PointCommand.Charge(userId, amount);
+
+            // when // then
+            assertThatThrownBy(() -> pointService.charge(command))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("해당되는 유저가 없습니다.");
+        }
+    }
+}

--- a/src/test/java/kr/server/pointly/domain/point/PointServiceTest.java
+++ b/src/test/java/kr/server/pointly/domain/point/PointServiceTest.java
@@ -1,0 +1,67 @@
+package kr.server.pointly.domain.point;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class PointServiceTest {
+
+    @Mock
+    private PointRepository pointRepository;
+
+    @Mock
+    private PointHistoryRepository pointHistoryRepository;
+
+    @InjectMocks
+    private PointService pointService;
+
+    @Nested
+    class Charge {
+        @DisplayName("올바른 userId로 포인트 충전을 요청하면 amount만큼 충전한 후 이력과 함께 저장된다.")
+        @Test
+        void success() {
+            // given
+            Long userId = 1L;
+            PointCommand.Charge command = new PointCommand.Charge(userId, 1000L);
+            when(pointRepository.findByUserId(command.userId()))
+                    .thenReturn(Optional.of(Point.create(userId, 0L)));
+            doNothing().when(pointHistoryRepository).save(any(PointHistory.class));
+            // when
+            Point chargedPoint = pointService.charge(command);
+
+            // then
+            assertThat(chargedPoint).isNotNull();
+            verify(pointRepository, times(1)).findByUserId(userId);
+            verify(pointHistoryRepository, times(1)).save(any(PointHistory.class));
+        }
+
+        @DisplayName("포인트 충전에 실패한 경우 이력은 저장되지 않는다.")
+        @Test
+        void fail() {
+            // given
+            PointCommand.Charge command = new PointCommand.Charge(1L, 1000L);
+
+            // when
+            assertThatThrownBy(() -> pointService.charge(command));
+
+            // then
+            verify(pointHistoryRepository, never()).save(any(PointHistory.class));
+        }
+
+    }
+
+
+}

--- a/src/test/java/kr/server/pointly/domain/point/PointTest.java
+++ b/src/test/java/kr/server/pointly/domain/point/PointTest.java
@@ -1,0 +1,43 @@
+package kr.server.pointly.domain.point;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+class PointTest {
+
+    @Nested
+    class Charge{
+
+        @DisplayName("포인트 충전 시 원래 보유하고 있던 포인트에 충전 요청한 금액을 더한 값을 포인트로 가진다.")
+        @Test
+        void success() {
+            // given
+            Point point = Point.create(1L, 1000L);
+            Long amount = 1000L;
+
+            // when
+            point.charge(amount);
+
+            // then
+            assertThat(point.getBalance()).isEqualTo(2000L);
+        }
+
+        @DisplayName("0이하의 값을 충전하려는 경우 IllegalArgumentException 발생한다.")
+        @Test
+        void failByZeroAmount() {
+            // given
+            Point point = Point.create(1L, 1000L);
+
+            // when // then
+            assertThatThrownBy(() -> point.charge(0L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("포인트 충전은 1원 이상부터 가능합니다.");
+        }
+    }
+
+}


### PR DESCRIPTION
## ISSUE
- #7 

## PR 내용
- Point 도메인을 구현하였습니다.
- Point는 충전 시 PointHistory라는 이력이 함께 저장됩니다.
- Point 충전에 동시성 이슈가 발생할 수 있어 '결제'와 함께 진행해야 하는 특성 상 충돌이 적다고 판단, JPA Optimistic Lock을 적용하였습니다.